### PR TITLE
Handle Interest Charges where textRight.length < 2.

### DIFF
--- a/geminiTransactionScrape.user.js
+++ b/geminiTransactionScrape.user.js
@@ -93,9 +93,13 @@ function script() {
                 const amount = textRight[0].textContent.trim().replace(/,/g, '').replace("Processing", function(){processing = true; return "";});
                 var dataRow = "";
                 if (amount.slice(0, 1) != "-") {
-                    var reward_percent = textRight[1].textContent;
-                    if (textRight.length == 3) {
+                    if (textRight.length > 1) {
+                      var reward_percent = textRight[1].textContent;
+                      if (textRight.length == 3) {
                         reward_percent += " + " + textRight[2].textContent;
+                      }
+                    } else {
+                      reward_percent = 0;
                     }
                     dataRow = `${formattedDate},${merchant},,Gemini Credit,,Reward: ${reward_percent},-${amount}\n`;
                 } else {


### PR DESCRIPTION
From my experiments it looks like interest charges have a textRight.length of 1, so checking for textRight[1] would give an error. Also, I think that reward_percent is probably 0 for interest charges.